### PR TITLE
feat: add bus stop regulatory element

### DIFF
--- a/tmp/lanelet2_extension/CMakeLists.txt
+++ b/tmp/lanelet2_extension/CMakeLists.txt
@@ -44,6 +44,7 @@ ament_auto_add_library(lanelet2_extension_lib SHARED
   lib/virtual_traffic_light.cpp
   lib/visualization.cpp
   lib/route_checker.cpp
+  lib/bus_stop.cpp
 )
 target_link_libraries(lanelet2_extension_lib
   ${GeographicLib_LIBRARIES}

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/bus_stop.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/bus_stop.hpp
@@ -1,0 +1,96 @@
+// Copyright 2015-2019 Autoware Foundation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Ryohsuke Mitsudome
+
+#ifndef LANELET2_EXTENSION__REGULATORY_ELEMENTS__BUS_STOP_HPP_
+#define LANELET2_EXTENSION__REGULATORY_ELEMENTS__BUS_STOP_HPP_
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <memory>
+#include <vector>
+
+namespace lanelet::autoware
+{
+class BusStop : public lanelet::RegulatoryElement
+{
+public:
+  using Ptr = std::shared_ptr<BusStop>;
+  static constexpr char RuleName[] = "bus_stop";
+
+  //! Directly construct a stop line from its required rule parameters.
+  //! Might modify the input data in oder to get correct tags.
+  static Ptr make(
+    Id id, const AttributeMap & attributes, const Polygons3d & busStops,
+    const LineString3d & stopLine)
+  {
+    return Ptr{new BusStop(id, attributes, busStops, stopLine)};
+  }
+
+  /**
+   * @brief get the relevant bus_stops
+   * @return bus_stops
+   */
+  [[nodiscard]] ConstPolygons3d busStops() const;
+  [[nodiscard]] Polygons3d busStops();
+
+  /**
+   * @brief add a new bus stop
+   * @param primitive bus stop to add
+   */
+  void addBusStop(const Polygon3d & primitive);
+
+  /**
+   * @brief remove a bus stop
+   * @param primitive the primitive
+   * @return true if the bus stop existed and was removed
+   */
+  bool removeBusStop(const Polygon3d & primitive);
+
+  /**
+   * @brief get the stop line for the bus stop
+   * @return the stop line as LineString
+   */
+  [[nodiscard]] ConstLineString3d stopLine() const;
+  [[nodiscard]] LineString3d stopLine();
+
+  /**
+   * @brief set a new stop line, overwrite the old one
+   * @param stopLine new stop line
+   */
+  void setStopLine(const LineString3d & stopLine);
+
+  //! Deletes the stop line
+  void removeStopLine();
+
+private:
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class lanelet::RegisterRegulatoryElement<BusStop>;
+  BusStop(
+    Id id, const AttributeMap & attributes, const Polygons3d & busStops,
+    const LineString3d & stopLine);
+  explicit BusStop(const lanelet::RegulatoryElementDataPtr & data);
+};
+static lanelet::RegisterRegulatoryElement<BusStop> regBusStop;
+
+}  // namespace lanelet::autoware
+
+// NOLINTEND(readability-identifier-naming)
+
+#endif  // LANELET2_EXTENSION__REGULATORY_ELEMENTS__BUS_STOP_HPP_

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -20,6 +20,7 @@
 // NOLINTBEGIN(readability-identifier-naming)
 
 #include "lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
+#include "lanelet2_extension/regulatory_elements/bus_stop.hpp"
 #include "lanelet2_extension/regulatory_elements/detection_area.hpp"
 #include "lanelet2_extension/regulatory_elements/no_stopping_area.hpp"
 #include "lanelet2_extension/regulatory_elements/speed_bump.hpp"
@@ -43,6 +44,7 @@ using AutowareTrafficLightConstPtr = std::shared_ptr<const lanelet::autoware::Au
 using DetectionAreaConstPtr = std::shared_ptr<const lanelet::autoware::DetectionArea>;
 using NoStoppingAreaConstPtr = std::shared_ptr<const lanelet::autoware::NoStoppingArea>;
 using SpeedBumpConstPtr = std::shared_ptr<const lanelet::autoware::SpeedBump>;
+using BusStopConstPtr = std::shared_ptr<const lanelet::autoware::BusStop>;
 }  // namespace lanelet
 
 namespace lanelet::utils::query
@@ -122,6 +124,13 @@ std::vector<lanelet::NoStoppingAreaConstPtr> noStoppingAreas(
  * @return         [speed bumps that are associated with input lanelets]
  */
 std::vector<lanelet::SpeedBumpConstPtr> speedBumps(const lanelet::ConstLanelets & lanelets);
+
+/**
+ * [busStops extracts Bus Stop regulatory elements from lanelets]
+ * @param lanelets [input lanelets]
+ * @return         [bus stops that are associated with input lanelets]
+ */
+std::vector<lanelet::BusStopConstPtr> busStops(const lanelet::ConstLanelets & lanelets);
 
 // query all polygons that has given type in lanelet2 map
 lanelet::ConstPolygons3d getAllPolygonsByType(

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -243,12 +243,12 @@ visualization_msgs::msg::MarkerArray speedBumpsAsMarkerArray(
 
 /**
  * [busStopsAsMarkerArray creates marker array to visualize bus stops]
- * @param  da_reg_elems [bus stop regulatory elements]
+ * @param  bs_reg_elems [bus stop regulatory elements]
  * @param  c            [color of the marker]
  * @param  duration     [lifetime of the marker]
  */
 visualization_msgs::msg::MarkerArray busStopsAsMarkerArray(
-  const std::vector<lanelet::BusStopConstPtr> & da_reg_elems, const std_msgs::msg::ColorRGBA & c,
+  const std::vector<lanelet::BusStopConstPtr> & bs_reg_elems, const std_msgs::msg::ColorRGBA & c,
   const rclcpp::Duration & duration = rclcpp::Duration(0, 0));
 
 /**

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -242,6 +242,16 @@ visualization_msgs::msg::MarkerArray speedBumpsAsMarkerArray(
   const rclcpp::Duration & duration = rclcpp::Duration(0, 0));
 
 /**
+ * [busStopsAsMarkerArray creates marker array to visualize bus stops]
+ * @param  da_reg_elems [bus stop regulatory elements]
+ * @param  c            [color of the marker]
+ * @param  duration     [lifetime of the marker]
+ */
+visualization_msgs::msg::MarkerArray busStopsAsMarkerArray(
+  const std::vector<lanelet::BusStopConstPtr> & da_reg_elems, const std_msgs::msg::ColorRGBA & c,
+  const rclcpp::Duration & duration = rclcpp::Duration(0, 0));
+
+/**
  * [pedestrianMarkingsAsMarkerArray creates marker array to visualize pedestrian markings]
  * @param  pedestrian_markings [pedestrian marking polygon]
  * @param  c            [color of the marker]

--- a/tmp/lanelet2_extension/lib/bus_stop.cpp
+++ b/tmp/lanelet2_extension/lib/bus_stop.cpp
@@ -1,0 +1,148 @@
+// Copyright 2015-2019 Autoware Foundation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Ryohsuke Mitsudome
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+#include "lanelet2_extension/regulatory_elements/bus_stop.hpp"
+
+#include <boost/variant.hpp>
+
+#include <lanelet2_core/primitives/RegulatoryElement.h>
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace lanelet::autoware
+{
+namespace
+{
+template <typename T>
+bool findAndErase(const T & primitive, RuleParameters * member)
+{
+  if (member == nullptr) {
+    std::cerr << __FUNCTION__ << ": member is null pointer";
+    return false;
+  }
+  auto it = std::find(member->begin(), member->end(), RuleParameter(primitive));
+  if (it == member->end()) {
+    return false;
+  }
+  member->erase(it);
+  return true;
+}
+
+template <typename T>
+RuleParameters toRuleParameters(const std::vector<T> & primitives)
+{
+  auto cast_func = [](const auto & elem) { return static_cast<RuleParameter>(elem); };
+  return utils::transform(primitives, cast_func);
+}
+
+// template <>
+// RuleParameters toRuleParameters(const std::vector<Polygon3d>& primitives)
+// {
+//   auto cast_func = [](const auto& elem) { return elem.asRuleParameter(); };
+//   return utils::transform(primitives, cast_func);
+// }
+
+Polygons3d getPoly(const RuleParameterMap & paramsMap, RoleName role)
+{
+  auto params = paramsMap.find(role);
+  if (params == paramsMap.end()) {
+    return {};
+  }
+
+  Polygons3d result;
+  for (auto & param : params->second) {
+    auto p = boost::get<Polygon3d>(&param);
+    if (p != nullptr) {
+      result.push_back(*p);
+    }
+  }
+  return result;
+}
+
+ConstPolygons3d getConstPoly(const RuleParameterMap & params, RoleName role)
+{
+  auto cast_func = [](auto & poly) { return static_cast<ConstPolygon3d>(poly); };
+  return utils::transform(getPoly(params, role), cast_func);
+}
+
+RegulatoryElementDataPtr constructBusStopData(
+  Id id, const AttributeMap & attributes, const Polygons3d & busStops,
+  const LineString3d & stopLine)
+{
+  RuleParameterMap rpm = {{RoleNameString::Refers, toRuleParameters(busStops)}};
+
+  RuleParameters rule_parameters = {stopLine};
+  rpm.insert(std::make_pair(RoleNameString::RefLine, rule_parameters));
+
+  auto data = std::make_shared<RegulatoryElementData>(id, rpm, attributes);
+  data->attributes[AttributeName::Type] = AttributeValueString::RegulatoryElement;
+  data->attributes[AttributeName::Subtype] = "bus_stop";
+  return data;
+}
+}  // namespace
+
+BusStop::BusStop(const RegulatoryElementDataPtr & data) : RegulatoryElement(data)
+{
+  if (getConstPoly(data->parameters, RoleName::Refers).empty()) {
+    throw InvalidInputError("No bus stop defined!");
+  }
+  if (getParameters<ConstLineString3d>(RoleName::RefLine).size() != 1) {
+    throw InvalidInputError("There must be exactly one stopline defined!");
+  }
+}
+
+BusStop::BusStop(
+  Id id, const AttributeMap & attributes, const Polygons3d & busStops,
+  const LineString3d & stopLine)
+: BusStop(constructBusStopData(id, attributes, busStops, stopLine))
+{
+}
+
+ConstPolygons3d BusStop::busStops() const { return getConstPoly(parameters(), RoleName::Refers); }
+Polygons3d BusStop::busStops() { return getPoly(parameters(), RoleName::Refers); }
+
+void BusStop::addBusStop(const Polygon3d & primitive)
+{
+  parameters()["bus_stop"].emplace_back(primitive);
+}
+
+bool BusStop::removeBusStop(const Polygon3d & primitive)
+{
+  return findAndErase(primitive, &parameters().find("bus_stop")->second);
+}
+
+ConstLineString3d BusStop::stopLine() const
+{
+  return getParameters<ConstLineString3d>(RoleName::RefLine).front();
+}
+
+LineString3d BusStop::stopLine() { return getParameters<LineString3d>(RoleName::RefLine).front(); }
+
+void BusStop::setStopLine(const LineString3d & stopLine)
+{
+  parameters()[RoleName::RefLine] = {stopLine};
+}
+
+void BusStop::removeStopLine() { parameters()[RoleName::RefLine] = {}; }
+
+}  // namespace lanelet::autoware
+
+// NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -240,6 +240,34 @@ std::vector<lanelet::SpeedBumpConstPtr> query::speedBumps(const lanelet::ConstLa
   return sb_reg_elems;
 }
 
+std::vector<lanelet::BusStopConstPtr> query::busStops(const lanelet::ConstLanelets & lanelets)
+{
+  std::vector<lanelet::BusStopConstPtr> da_reg_elems;
+
+  for (const auto & ll : lanelets) {
+    std::vector<lanelet::BusStopConstPtr> ll_da_re =
+      ll.regulatoryElementsAs<lanelet::autoware::BusStop>();
+
+    // insert unique tl into array
+    for (const auto & da_ptr : ll_da_re) {
+      lanelet::Id id = da_ptr->id();
+      bool unique_id = true;
+
+      for (const auto & da_reg_elem : da_reg_elems) {
+        if (id == da_reg_elem->id()) {
+          unique_id = false;
+          break;
+        }
+      }
+
+      if (unique_id) {
+        da_reg_elems.push_back(da_ptr);
+      }
+    }
+  }
+  return da_reg_elems;
+}
+
 lanelet::ConstPolygons3d query::getAllPolygonsByType(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & polygon_type)
 {

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -792,14 +792,14 @@ visualization_msgs::msg::MarkerArray visualization::speedBumpsAsMarkerArray(
 }
 
 visualization_msgs::msg::MarkerArray visualization::busStopsAsMarkerArray(
-  const std::vector<lanelet::BusStopConstPtr> & da_reg_elems, const std_msgs::msg::ColorRGBA & c,
+  const std::vector<lanelet::BusStopConstPtr> & bs_reg_elems, const std_msgs::msg::ColorRGBA & c,
   const rclcpp::Duration & duration)
 {
   visualization_msgs::msg::MarkerArray marker_array;
   visualization_msgs::msg::Marker marker;
   visualization_msgs::msg::Marker line_marker;
 
-  if (da_reg_elems.empty()) {
+  if (bs_reg_elems.empty()) {
     return marker_array;
   }
 
@@ -832,13 +832,13 @@ visualization_msgs::msg::MarkerArray visualization::busStopsAsMarkerArray(
   line_c.a = 0.999;
   visualization::initLineStringMarker(&line_marker, "map", "bus_stop_stopline", line_c);
 
-  for (const auto & da_reg_elem : da_reg_elems) {
+  for (const auto & bs_reg_elem : bs_reg_elems) {
     marker.points.clear();
     marker.colors.clear();
-    marker.id = static_cast<int32_t>(da_reg_elem->id());
+    marker.id = static_cast<int32_t>(bs_reg_elem->id());
 
     // area visualization
-    const auto bus_stops = da_reg_elem->busStops();
+    const auto bus_stops = bs_reg_elem->busStops();
     for (const auto & bus_stop : bus_stops) {
       geometry_msgs::msg::Polygon geom_poly;
       utils::conversion::toGeomMsgPoly(bus_stop, &geom_poly);
@@ -859,7 +859,7 @@ visualization_msgs::msg::MarkerArray visualization::busStopsAsMarkerArray(
     marker_array.markers.push_back(marker);
 
     // stop line visualization
-    visualization::pushLineStringMarker(&line_marker, da_reg_elem->stopLine(), line_c, 0.5);
+    visualization::pushLineStringMarker(&line_marker, bs_reg_elem->stopLine(), line_c, 0.5);
   }  // for regulatory elements
 
   marker_array.markers.push_back(line_marker);


### PR DESCRIPTION
## Description

Added regulatory element for bus stop module.

- Related PRs
  - https://github.com/tier4/autoware.universe/pull/339
  - https://github.com/tier4/autoware_launch.x2/pull/264
  - https://github.com/tier4/autoware_common/pull/2 **(This PR)**
  - https://github.com/tier4/tier4_autoware_msgs/pull/78

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
